### PR TITLE
Add Bootswatch theme and update DataTables

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,80 +1,64 @@
 <!DOCTYPE html>
-<html lang = "en">
-
-<div class="container-fluid">
-  <head style="background-color:#f6f6f6">
-    <meta charset="UTF-8">
-    <meta name="viewport" content="wid=device-width, intial-scale=1.0">
-  
-    <!-- Bootstrap -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-    <link href="https://cdn.datatables.net/v/dt/dt-2.0.7/datatables.min.css" rel="stylesheet">
-    <script src="https://cdn.datatables.net/v/dt/dt-2.0.7/datatables.min.js"></script>
-
-
-    <meta name="viewport" content = "width=device-width, initial-scale=1.0">
-    <style type="text/css">
-      html,
-      body {
-        height:100%;
-        padding-top: 20px;
-      }
-    .table-responsive{
-      height:700px; 
-      overflow:scroll;
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <!-- Bootswatch theme -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/minty/bootstrap.min.css">
+  <!-- Bootstrap icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <link href="https://cdn.datatables.net/v/dt/dt-2.0.7/datatables.min.css" rel="stylesheet">
+  <script src="https://cdn.datatables.net/v/dt/dt-2.0.7/datatables.min.js"></script>
+  <style>
+    body {
+      padding-top: 70px;
+      min-height: 100vh;
     }
-    thead tr:nth-child(1) th{
+    thead th {
       position: sticky;
       top: -1px;
       z-index: 10;
     }
-    </style>
-
-    <br>
-    <nav class = "navbar fixed-top bg-light">
-      <div class="row justify-content-start">
-        <div class="col-sm-auto">
-          <h2>
-            <a href="{{ url_for('index') }}" style="text-decoration: none">mARC Query</a>
-          </h2>
-        </div>
-        <div class="col-sm-auto">
-          <ul class="nav nav-pills">
-            <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('index') }}">Home</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('browse_aliquots') }}">Aliquots</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('browse_isolates') }}">Isolates</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('query') }}">Custom Query</a>
-            </li>
-          </ul>
-        </div>
-        <div class="col-sm-auto">
-        </div>
+  </style>
+  {% block head %}{% endblock %}
+</head>
+<body class="container-fluid">
+  <nav class="navbar navbar-expand-lg bg-light fixed-top">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="{{ url_for('index') }}">mARC Query</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu" aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navMenu">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('index') }}"><i class="bi bi-house-fill"></i> Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('browse_aliquots') }}"><i class="bi bi-vial"></i> Aliquots</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('browse_isolates') }}"><i class="bi bi-bug-fill"></i> Isolates</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('query') }}"><i class="bi bi-search"></i> Custom Query</a>
+          </li>
+        </ul>
       </div>
-    </nav>
- 
-    {% block head %}{% endblock %}
+    </div>
+  </nav>
 
-  </head>
-</div>
-
-<body>
   <script>
-    $(function () {
-      $('[data-toggle="popover"]')
-        .popover({
-          placement : 'top',
-          trigger : 'hover',
-        })
-    })
+    document.addEventListener('DOMContentLoaded', function () {
+      document
+        .querySelectorAll('[data-bs-toggle="popover"]')
+        .forEach(function (el) {
+          new bootstrap.Popover(el, { placement: 'top', trigger: 'hover' });
+        });
+    });
   </script>
 
   {% block body %}{% endblock %}

--- a/app/templates/browse_aliquots.html
+++ b/app/templates/browse_aliquots.html
@@ -34,12 +34,12 @@
   <script type="text/javascript">
   $(document).ready(function () {
       /* Initialize the DataTable */
-      oTable = $('#aliquots').dataTable({
-          "bSort": false,
-          "iDisplayLength": 20,
-          "bLengthChange": false,
-          "sPaginationType": "full_numbers",
-          "bStateSave": true,
+      const oTable = $('#aliquots').DataTable({
+          ordering: false,
+          pageLength: 20,
+          lengthChange: false,
+          pagingType: 'full_numbers',
+          stateSave: true,
       });
   
       /* Move search box to bottom of summary area */

--- a/app/templates/browse_isolates.html
+++ b/app/templates/browse_isolates.html
@@ -42,12 +42,12 @@
   <script type="text/javascript">
   $(document).ready(function () {
       /* Initialize the DataTable */
-      oTable = $('#isolates').dataTable({
-          "bSort": false,
-          "iDisplayLength": 20,
-          "bLengthChange": false,
-          "sPaginationType": "full_numbers",
-          "bStateSave": true,
+      const oTable = $('#isolates').DataTable({
+          ordering: false,
+          pageLength: 20,
+          lengthChange: false,
+          pagingType: 'full_numbers',
+          stateSave: true,
       });
   
       /* Move search box to bottom of summary area */

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,8 +1,8 @@
 {% extends 'base.html' %}
 
 {% block body %}
-<div id="summary" class="summary span-24 last">
-  <h2>Home Page</h2>
+<div class="container py-5 text-center">
+  <h2 class="mb-3">Home Page</h2>
   <p>More words here</p>
 </div>
 

--- a/app/templates/info.html
+++ b/app/templates/info.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block body %}
-<div>
+<div class="container py-5">
     <p>marc_web version: {{ version }}</p>
     <p>marc_db version: {{ marc_db_version }}</p>
 </div>

--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
 {% block body %}
+<div class="container py-5">
 <div class="d-flex flex-row">
   <div class="d-flex w-50 p-5 m-5 border border-black">
     <form class="d-flex flex-column w-100" method="POST" action="{{ url_for('query') }}">
@@ -22,6 +23,7 @@
     </div>
     {% endfor %}
   </div>
+</div>
 </div>
 
 {% if error is defined %}
@@ -64,12 +66,12 @@
 <script type="text/javascript">
 $(document).ready(function () {
     /* Initialize the DataTable */
-    oTable = $('#results').dataTable({
-        "bSort": false,
-        "iDisplayLength": 20,
-        "bLengthChange": false,
-        "sPaginationType": "full_numbers",
-        "bStateSave": true,
+    const oTable = $('#results').DataTable({
+        ordering: false,
+        pageLength: 20,
+        lengthChange: false,
+        pagingType: 'full_numbers',
+        stateSave: true,
     });
 
     /* Move search box to bottom of summary area */


### PR DESCRIPTION
## Summary
- restyle site with Bootswatch Minty and Bootstrap icons
- fix DataTables initialization for v2
- clean layout of index, info and query pages
- bootstrap v5 popover initialization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865a5e145b483238ba11dcd5def54da