### PR TITLE
Refactor DataTable setup

### DIFF
--- a/app/static/table.js
+++ b/app/static/table.js
@@ -1,0 +1,9 @@
+function createDataTable(selector) {
+  return $(selector).DataTable({
+    ordering: false,
+    pageLength: 20,
+    lengthChange: false,
+    pagingType: 'full_numbers',
+    stateSave: true,
+  });
+}

--- a/app/static/table.js
+++ b/app/static/table.js
@@ -1,4 +1,4 @@
-function createDataTable(selector) {
+export function createDataTable(selector) {
   return $(selector).DataTable({
     ordering: false,
     pageLength: 20,

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
   <link href="https://cdn.datatables.net/v/dt/dt-2.0.7/datatables.min.css" rel="stylesheet">
   <script src="https://cdn.datatables.net/v/dt/dt-2.0.7/datatables.min.js"></script>
+  <script src="{{ url_for('static', filename='table.js') }}"></script>
   <style>
     body {
       padding-top: 70px;

--- a/app/templates/browse_aliquots.html
+++ b/app/templates/browse_aliquots.html
@@ -34,13 +34,7 @@
   <script type="text/javascript">
   $(document).ready(function () {
       /* Initialize the DataTable */
-      const oTable = $('#aliquots').DataTable({
-          ordering: false,
-          pageLength: 20,
-          lengthChange: false,
-          pagingType: 'full_numbers',
-          stateSave: true,
-      });
+      const oTable = createDataTable('#aliquots');
   
       /* Move search box to bottom of summary area */
       $("#aliquots_filter").appendTo('#aliquots_summary');
@@ -51,7 +45,7 @@
   
       /* Moving the search box breaks the state saving routine */
       /* Redraw manually */
-      oTable.fnDraw();
+      oTable.draw();
   });
   </script>
 {% endblock %}

--- a/app/templates/browse_isolates.html
+++ b/app/templates/browse_isolates.html
@@ -42,13 +42,7 @@
   <script type="text/javascript">
   $(document).ready(function () {
       /* Initialize the DataTable */
-      const oTable = $('#isolates').DataTable({
-          ordering: false,
-          pageLength: 20,
-          lengthChange: false,
-          pagingType: 'full_numbers',
-          stateSave: true,
-      });
+      const oTable = createDataTable('#isolates');
   
       /* Move search box to bottom of summary area */
       $("#isolates_filter").appendTo('#isolates_summary');
@@ -59,7 +53,7 @@
   
       /* Moving the search box breaks the state saving routine */
       /* Redraw manually */
-      oTable.fnDraw();
+      oTable.draw();
   });
   </script>
 {% endblock %}

--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -66,13 +66,7 @@
 <script type="text/javascript">
 $(document).ready(function () {
     /* Initialize the DataTable */
-    const oTable = $('#results').DataTable({
-        ordering: false,
-        pageLength: 20,
-        lengthChange: false,
-        pagingType: 'full_numbers',
-        stateSave: true,
-    });
+    const oTable = createDataTable('#results');
 
     /* Move search box to bottom of summary area */
     $("#results_filter").appendTo('#results_summary');
@@ -83,7 +77,7 @@ $(document).ready(function () {
 
     /* Moving the search box breaks the state saving routine */
     /* Redraw manually */
-    oTable.fnDraw();
+    oTable.draw();
 });
 </script>
 {% endif %}


### PR DESCRIPTION
## Summary
- move DataTable initialization to a reusable JS helper
- load helper in base template
- use helper across templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f955bf708323823314ce022c31dc