### PR TITLE
Fix DataTable helper

### DIFF
--- a/app/static/table.js
+++ b/app/static/table.js
@@ -1,4 +1,4 @@
-export function createDataTable(selector) {
+function createDataTable(selector) {
   return $(selector).DataTable({
     ordering: false,
     pageLength: 20,


### PR DESCRIPTION
## Summary
- fix DataTable helper js by removing ES module export so it runs as a normal script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865fbb402648323ac334d3ddcea8057