### PR TITLE
Fix quoting bug in query results page

### DIFF
--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -64,7 +64,7 @@
 
 <script type="text/javascript">
 $(document).ready(function () {
-    const sql = `{{ query|tojson|safe }}`;
+    const sql = {{ query|tojson }};
     if (!sql) return;
 
     const columns = {{ columns|tojson }}.map(c => ({ data: c }));


### PR DESCRIPTION
## Summary
- avoid embedding query string in backticks so it isn't quoted

## Testing
- `black .`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_687952fc9884832382016878d1031e61