### PR TITLE
Fix SQLite search in datatables

### DIFF
--- a/app/datatables.py
+++ b/app/datatables.py
@@ -117,8 +117,9 @@ def datatables_response(query):
     if not isinstance(query, Select):
         raise TypeError("query must be a SQLAlchemy Select, Query, or SQL string")
 
+    # Ensure ORM selections return column mappings instead of model objects
     columns = [c.key for c in query.selected_columns]
-    base_query = query
+    base_query = query.with_only_columns(query.selected_columns)
     total_records = _execute_count(base_query)
 
     values = request.values


### PR DESCRIPTION
## Summary
- handle SQLite `LIKE` searches in datatables

## Testing
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a5d7a4e248323b4e09ca462706558