### PR TITLE
Add CodeMirror autocomplete to query editor

### DIFF
--- a/app/static/query_editor.js
+++ b/app/static/query_editor.js
@@ -1,15 +1,21 @@
-function initQueryEditor(textareaId, tables) {
-  var editor = CodeMirror.fromTextArea(document.getElementById(textareaId), {
-    mode: 'text/x-sql',
+function initQueryEditor(containerId, hiddenInputId, tables) {
+  const input = document.getElementById(hiddenInputId);
+  const editor = CodeMirror(document.getElementById(containerId), {
+    value: input.value || "",
+    mode: "text/x-sql",
     lineNumbers: true,
-    extraKeys: { 'Ctrl-Space': 'autocomplete' },
-    hintOptions: { tables: tables }
+    extraKeys: { "Ctrl-Space": "autocomplete" },
+    hintOptions: { tables: tables },
   });
 
-  var form = document.getElementById(textareaId).form;
+  editor.on("change", function (cm) {
+    input.value = cm.getValue();
+  });
+
+  const form = input.form;
   if (form) {
-    form.addEventListener('submit', function () {
-      editor.save();
+    form.addEventListener("submit", function () {
+      input.value = editor.getValue();
     });
   }
   return editor;

--- a/app/static/query_editor.js
+++ b/app/static/query_editor.js
@@ -1,0 +1,16 @@
+function initQueryEditor(textareaId, tables) {
+  var editor = CodeMirror.fromTextArea(document.getElementById(textareaId), {
+    mode: 'text/x-sql',
+    lineNumbers: true,
+    extraKeys: { 'Ctrl-Space': 'autocomplete' },
+    hintOptions: { tables: tables }
+  });
+
+  var form = document.getElementById(textareaId).form;
+  if (form) {
+    form.addEventListener('submit', function () {
+      editor.save();
+    });
+  }
+  return editor;
+}

--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 
 {% block head %}
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.css" integrity="sha512-/Fkzb5V4TXN0Wh05rq6ArlTc95xJMu38xpv8uKXuX4nHCqB6f+GO6zkRgZNpmjDoE7YQDdyCjTiMQuYzfoalYg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/show-hint.min.css" integrity="sha512-rJEqXWiwxupCSvJzpuG1HsfrN7kYMva9n32CuWHa3gwxObn2ymlk/wEYBLETymFcpnSUsctNkYheAQ7Ez+KJAA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.js" integrity="sha512-+KDgj6/mswHxZ34rnOG0r8QwMCKa2QW2LaxhUJW6Ka7O5Kb/6VQwWi4KFOeFHrgb3R04QLbTjaCj1eO0MJdAig==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/mode/sql/sql.min.js" integrity="sha512-KEuWiRiwXQDq6rqcQXWfBsB1bt0osLOYTdSd5quN4dStEUAkknvXqZ/xJz5lG1fV64D7Bqjofu5pY88MtXH8mw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/show-hint.min.js" integrity="sha512-Y3xJEBhDigw1VE3DybZ0SqnX+ANXoy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdFM5lTyBC0bYKT1eZq9w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/sql-hint.min.js" integrity="sha512-qLCRa14Q6gttYVOlJawVSdGInxjeRGna43EIBgzHuLlHotE5RX7V6czS4fFqqpwPIYOvTo95OfzmiEJeZVrDQA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.css" integrity="sha384-zaeBlB/vwYsDRSlFajnDd7OydJ0cWk+c2OWybl3eSUf6hW2EbhlCsQPqKr3gkznT" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/show-hint.min.css" integrity="sha384-TU/qRI67N04B589luYdn1ZMRIGgJic3GB1WsvLJTRh92VO26vpxI4dCKiDtsR4fw" crossorigin="anonymous">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.js" integrity="sha384-etl3CBZukqWrVg3VFnSxRIEjaeOJLzTxWK7TPk/klS4l9MNGGr6lptVNs7N2pRoy" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/mode/sql/sql.min.js" integrity="sha384-0uq6A2QqmgmRGhd86vTHGFSpPgWWSMh3F1JDgMohYMKXxt+YP/ogivHjVGGn3hAb" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/show-hint.min.js" integrity="sha384-WmEJUmIUFrVWqznkNFnAW2/vQ9X3VlvhPDvttjgqECGqnBrcZckvN2xxYVXLRjpv" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/sql-hint.min.js" integrity="sha384-/zA48l8PZlHrlpopG1QN+WL/Oaz3gRw2c4u4xMFMF6u9qtk2nJyGgpTDVhljcPDK" crossorigin="anonymous"></script>
   <script src="{{ url_for('static', filename='query_editor.js') }}"></script>
 {% endblock %}
 

--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -16,7 +16,8 @@
   <div class="d-flex w-50 p-5 m-5 border border-black">
     <form class="d-flex flex-column w-100" method="POST" action="{{ url_for('query') }}">
       <label class="p-2">Custom Query</label>
-      <textarea id="query" name="query" class="w-100 p-2" rows="10">{{ query }}</textarea>
+      <input type="hidden" id="query-input" name="query" value="{{ query }}">
+      <div id="query-editor" class="w-100 border" style="height: 300px;"></div>
       <button type="submit" id="submit" class="my-2 p-2">Submit</button>
     </form>
   </div>
@@ -107,7 +108,7 @@ $(document).ready(function () {
   $("#model-select").on("change", updateFields);
   $(document).ready(function () {
     updateFields();
-    window.queryEditor = initQueryEditor('query', modelFields);
+    window.queryEditor = initQueryEditor('query-editor', 'query-input', modelFields);
   });
 </script>
 {% endblock %}

--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -1,5 +1,15 @@
 {% extends 'base.html' %}
 
+{% block head %}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.css" integrity="sha512-/Fkzb5V4TXN0Wh05rq6ArlTc95xJMu38xpv8uKXuX4nHCqB6f+GO6zkRgZNpmjDoE7YQDdyCjTiMQuYzfoalYg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/show-hint.min.css" integrity="sha512-rJEqXWiwxupCSvJzpuG1HsfrN7kYMva9n32CuWHa3gwxObn2ymlk/wEYBLETymFcpnSUsctNkYheAQ7Ez+KJAA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.js" integrity="sha512-+KDgj6/mswHxZ34rnOG0r8QwMCKa2QW2LaxhUJW6Ka7O5Kb/6VQwWi4KFOeFHrgb3R04QLbTjaCj1eO0MJdAig==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/mode/sql/sql.min.js" integrity="sha512-KEuWiRiwXQDq6rqcQXWfBsB1bt0osLOYTdSd5quN4dStEUAkknvXqZ/xJz5lG1fV64D7Bqjofu5pY88MtXH8mw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/show-hint.min.js" integrity="sha512-Y3xJEBhDigw1VE3DybZ0SqnX+ANXoy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkprdFM5lTyBC0bYKT1eZq9w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/addon/hint/sql-hint.min.js" integrity="sha512-qLCRa14Q6gttYVOlJawVSdGInxjeRGna43EIBgzHuLlHotE5RX7V6czS4fFqqpwPIYOvTo95OfzmiEJeZVrDQA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="{{ url_for('static', filename='query_editor.js') }}"></script>
+{% endblock %}
+
 {% block body %}
 <div class="container py-5">
 <div class="d-flex flex-row">
@@ -83,6 +93,7 @@ $(document).ready(function () {
 {% endif %}
 <script type="text/javascript">
   const modelFields = {{ model_fields | tojson }};
+
   function updateFields() {
     const selected = $("#model-select").val();
     const fields = modelFields[selected] || [];
@@ -92,9 +103,11 @@ $(document).ready(function () {
       list.append($("<li>").text(f));
     }
   }
+
   $("#model-select").on("change", updateFields);
   $(document).ready(function () {
     updateFields();
+    window.queryEditor = initQueryEditor('query', modelFields);
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add CodeMirror JS editor initialization script
- include CodeMirror assets on query page and initialize editor

## Testing
- `black . --quiet`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac0b657008323a8382398f12b0e29