### PR TITLE
Add Assembly table views

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -117,6 +117,46 @@ def show_aliquot(aliquot_id):
     return render_template("show_aliquot.html", aliquot=aliquot[0])
 
 
+@app.route("/assemblies")
+def browse_assemblies():
+    return render_template("browse_assemblies.html")
+
+
+@app.route("/api/assemblies")
+def api_assemblies():
+    return datatables_response(select(Assembly))
+
+
+@app.route("/assembly_qc")
+def browse_assembly_qc():
+    return render_template("browse_assembly_qc.html")
+
+
+@app.route("/api/assembly_qc")
+def api_assembly_qc():
+    return datatables_response(select(AssemblyQC))
+
+
+@app.route("/taxonomic_assignments")
+def browse_taxonomic_assignments():
+    return render_template("browse_taxonomic_assignments.html")
+
+
+@app.route("/api/taxonomic_assignments")
+def api_taxonomic_assignments():
+    return datatables_response(select(TaxonomicAssignment))
+
+
+@app.route("/antimicrobials")
+def browse_antimicrobials():
+    return render_template("browse_antimicrobials.html")
+
+
+@app.route("/api/antimicrobials")
+def api_antimicrobials():
+    return datatables_response(select(Antimicrobial))
+
+
 @app.route("/query", methods=["GET", "POST"])
 def query():
     """Render the query form and determine column names for the SQL."""

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -45,6 +45,17 @@
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('browse_isolates') }}"><i class="bi bi-bug-fill"></i> Isolates</a>
           </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="assemblyDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <i class="bi bi-hdd-stack-fill"></i> Assembly
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="assemblyDropdown">
+              <li><a class="dropdown-item" href="{{ url_for('browse_assemblies') }}">Assemblies</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('browse_assembly_qc') }}">Assembly QC</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('browse_taxonomic_assignments') }}">Taxonomic Assignments</a></li>
+              <li><a class="dropdown-item" href="{{ url_for('browse_antimicrobials') }}">Antimicrobials</a></li>
+            </ul>
+          </li>
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('query') }}"><i class="bi bi-search"></i> Custom Query</a>
           </li>

--- a/app/templates/browse_antimicrobials.html
+++ b/app/templates/browse_antimicrobials.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+
+{% block body %}
+<div id="antimicrobials_summary" class="summary span-24 last">
+  <h2>Antimicrobials</h2>
+</div>
+
+<div class="d-flex flex-row">
+  <div class="d-flex p-5">
+    <table class="display" id="antimicrobials">
+      <thead>
+        <tr>
+          <th>Assembly ID</th>
+          <th>Isolate ID</th>
+          <th>Contig ID</th>
+          <th>Gene Symbol</th>
+          <th>Gene Name</th>
+          <th>Accession</th>
+          <th>Element Type</th>
+          <th>Resistance Product</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<script type="text/javascript">
+$(document).ready(function () {
+    const oTable = createServerDataTable('#antimicrobials', '{{ url_for('api_antimicrobials') }}', [
+        { data: 'assembly_id' },
+        { data: 'isolate_id' },
+        { data: 'contig_id' },
+        { data: 'gene_symbol' },
+        { data: 'gene_name' },
+        { data: 'accession' },
+        { data: 'element_type' },
+        { data: 'resistance_product' }
+    ]);
+
+    $('#antimicrobials_filter').appendTo('#antimicrobials_summary');
+    $('#antimicrobials_info').addClass('span-12');
+    $('#antimicrobials_paginate').addClass('span-12 last');
+    oTable.draw();
+});
+</script>
+{% endblock %}

--- a/app/templates/browse_assemblies.html
+++ b/app/templates/browse_assemblies.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+
+{% block body %}
+<div id="assemblies_summary" class="summary span-24 last">
+  <h2>Assemblies</h2>
+</div>
+
+<div class="d-flex flex-row">
+  <div class="d-flex p-5">
+    <table class="display" id="assemblies">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Isolate ID</th>
+          <th>Metagenomic Sample ID</th>
+          <th>Metagenomic Run ID</th>
+          <th>Run Number</th>
+          <th>Sunbeam Version</th>
+          <th>SBX SGA Version</th>
+          <th>Config File</th>
+          <th>Sunbeam Output Path</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<script type="text/javascript">
+$(document).ready(function () {
+    const oTable = createServerDataTable('#assemblies', '{{ url_for('api_assemblies') }}', [
+        { data: 'id' },
+        { data: 'isolate_id' },
+        { data: 'metagenomic_sample_id' },
+        { data: 'metagenomic_run_id' },
+        { data: 'run_number' },
+        { data: 'sunbeam_version' },
+        { data: 'sbx_sga_version' },
+        { data: 'config_file' },
+        { data: 'sunbeam_output_path' }
+    ]);
+
+    $('#assemblies_filter').appendTo('#assemblies_summary');
+    $('#assemblies_info').addClass('span-12');
+    $('#assemblies_paginate').addClass('span-12 last');
+    oTable.draw();
+});
+</script>
+{% endblock %}

--- a/app/templates/browse_assembly_qc.html
+++ b/app/templates/browse_assembly_qc.html
@@ -1,0 +1,55 @@
+{% extends 'base.html' %}
+
+{% block body %}
+<div id="assembly_qc_summary" class="summary span-24 last">
+  <h2>Assembly QC</h2>
+</div>
+
+<div class="d-flex flex-row">
+  <div class="d-flex p-5">
+    <table class="display" id="assembly_qc">
+      <thead>
+        <tr>
+          <th>Assembly ID</th>
+          <th>Isolate ID</th>
+          <th>Contig Count</th>
+          <th>Genome Size</th>
+          <th>N50</th>
+          <th>GC Content</th>
+          <th>CDS</th>
+          <th>Completeness</th>
+          <th>Contamination</th>
+          <th>Min Contig Coverage</th>
+          <th>Avg Contig Coverage</th>
+          <th>Max Contig Coverage</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<script type="text/javascript">
+$(document).ready(function () {
+    const oTable = createServerDataTable('#assembly_qc', '{{ url_for('api_assembly_qc') }}', [
+        { data: 'assembly_id' },
+        { data: 'isolate_id' },
+        { data: 'contig_count' },
+        { data: 'genome_size' },
+        { data: 'n50' },
+        { data: 'gc_content' },
+        { data: 'cds' },
+        { data: 'completeness' },
+        { data: 'contamination' },
+        { data: 'min_contig_coverage' },
+        { data: 'avg_contig_coverage' },
+        { data: 'max_contig_coverage' }
+    ]);
+
+    $('#assembly_qc_filter').appendTo('#assembly_qc_summary');
+    $('#assembly_qc_info').addClass('span-12');
+    $('#assembly_qc_paginate').addClass('span-12 last');
+    oTable.draw();
+});
+</script>
+{% endblock %}

--- a/app/templates/browse_taxonomic_assignments.html
+++ b/app/templates/browse_taxonomic_assignments.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+
+{% block body %}
+<div id="taxonomic_assignments_summary" class="summary span-24 last">
+  <h2>Taxonomic Assignments</h2>
+</div>
+
+<div class="d-flex flex-row">
+  <div class="d-flex p-5">
+    <table class="display" id="taxonomic_assignments">
+      <thead>
+        <tr>
+          <th>Assembly ID</th>
+          <th>Isolate ID</th>
+          <th>Taxonomic Classification</th>
+          <th>Taxonomic Abundance</th>
+          <th>ST</th>
+          <th>ST Schema</th>
+          <th>Allele Assignment</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+
+<script type="text/javascript">
+$(document).ready(function () {
+    const oTable = createServerDataTable('#taxonomic_assignments', '{{ url_for('api_taxonomic_assignments') }}', [
+        { data: 'assembly_id' },
+        { data: 'isolate_id' },
+        { data: 'taxonomic_classification' },
+        { data: 'taxonomic_abundance' },
+        { data: 'st' },
+        { data: 'st_schema' },
+        { data: 'allele_assignment' }
+    ]);
+
+    $('#taxonomic_assignments_filter').appendTo('#taxonomic_assignments_summary');
+    $('#taxonomic_assignments_info').addClass('span-12');
+    $('#taxonomic_assignments_paginate').addClass('span-12 last');
+    oTable.draw();
+});
+</script>
+{% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,6 +36,25 @@ def test_aliquots_page(client):
     assert "data" in data
 
 
+@pytest.mark.parametrize(
+    "page,api_endpoint",
+    [
+        ("/assemblies", "/api/assemblies"),
+        ("/assembly_qc", "/api/assembly_qc"),
+        ("/taxonomic_assignments", "/api/taxonomic_assignments"),
+        ("/antimicrobials", "/api/antimicrobials"),
+    ],
+)
+def test_assembly_tables(client, page, api_endpoint):
+    resp = client.get(page)
+    assert resp.status_code == 200
+
+    api_resp = client.get(f"{api_endpoint}?draw=1&start=0&length=5")
+    assert api_resp.status_code == 200
+    data = api_resp.get_json()
+    assert "data" in data
+
+
 def test_query_api(client):
     resp = client.post(
         "/api/query",


### PR DESCRIPTION
## Summary
- add dropdown Assembly menu
- create browse templates for assembly-related tables
- expose new routes and API endpoints
- test new pages

## Testing
- `black .`
- `pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_687e925d2ce48323b6fdcf80bc2ef3ae