### PR TITLE
Align custom query inputs with schema reference

### DIFF
--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -12,43 +12,47 @@
 
 {% block body %}
 <div class="container py-2">
-<div class="d-flex flex-row">
-  <div class="d-flex flex-column">
-    <form class="d-flex flex-column w-100" method="POST" action="{{ url_for('query') }}">
-      <label class="p-2">Custom Query</label>
-      <input type="hidden" id="query-input" name="query" value="{{ query }}">
-      <div id="query-editor" class="w-100 border" style="height: 300px; max-width: 300;"></div>
-      <button type="submit" id="submit" class="my-2 p-2">Submit</button>
-    </form>
+  <div class="row">
+    <div class="col-md-4 p-2">
+      <form class="d-flex flex-column w-100" method="POST" action="{{ url_for('query') }}">
+        <label class="p-2">Custom Query</label>
+        <input type="hidden" id="query-input" name="query" value="{{ query }}">
+        <div id="query-editor" class="w-100 border" style="height: 300px;"></div>
+        <button type="submit" id="submit" class="btn btn-primary mt-2">Submit</button>
+      </form>
+    </div>
 
-    <form class="d-flex flex-column w-50 p-5 m-5" method="POST" action="{{ url_for('api_nl_query') }}">
-      <label for="prompt" class="form-label">
-        Natural Language Query
-        <i class="bi bi-question-circle" tabindex="0" data-bs-toggle="popover"
-          data-bs-content="Ask a question about the data. The system will generate an SQL query to answer it."></i>
-      </label>
-      <textarea id="prompt" name="prompt" class="form-control mb-3" rows="3">{{ prompt }}</textarea>
-      <input type="hidden" name="query" value="{{ query }}">
-      <button type="submit" class="btn btn-primary">Submit</button>
-    </form>
-  </div>
+    <div class="col-md-4 p-2">
+      <form class="d-flex flex-column" method="POST" action="{{ url_for('api_nl_query') }}">
+        <label for="prompt" class="form-label">
+          Natural Language Query
+          <i class="bi bi-question-circle" tabindex="0" data-bs-toggle="popover"
+             data-bs-content="Ask a question about the data. The system will generate an SQL query to answer it."></i>
+        </label>
+        <textarea id="prompt" name="prompt" class="form-control mb-3" rows="3">{{ prompt }}</textarea>
+        <input type="hidden" name="query" value="{{ query }}">
+        <button type="submit" class="btn btn-primary mt-2">Submit</button>
+      </form>
+    </div>
 
-  <div class="d-flex flex-column w-50 p-5 m-5">
-    <label for="model-select" class="form-label">
-      Model Reference
-      <i class="bi bi-question-circle" tabindex="0" data-bs-toggle="popover"
-         data-bs-content="Select a model to view its fields. Use these field names to build custom SQL queries."></i>
-    </label>
-    <select id="model-select" class="form-select">
-      {% for model in models %}
-      <option value="{{ model.__table__.name }}">{{ model.__table__.name }}</option>
-      {% endfor %}
-    </select>
-    <div id="fields-container" class="mt-3">
-      <ul id="fields-list" class="mb-0"></ul>
+    <div class="col-md-4 p-2">
+      <div class="d-flex flex-column">
+        <label for="model-select" class="form-label">
+          Model Reference
+          <i class="bi bi-question-circle" tabindex="0" data-bs-toggle="popover"
+             data-bs-content="Select a model to view its fields. Use these field names to build custom SQL queries."></i>
+        </label>
+        <select id="model-select" class="form-select">
+          {% for model in models %}
+          <option value="{{ model.__table__.name }}">{{ model.__table__.name }}</option>
+          {% endfor %}
+        </select>
+        <div id="fields-container" class="mt-3">
+          <ul id="fields-list" class="mb-0"></ul>
+        </div>
+      </div>
     </div>
   </div>
-</div>
 </div>
 
 {% if error %}

--- a/app/templates/query.html
+++ b/app/templates/query.html
@@ -29,7 +29,7 @@
           <i class="bi bi-question-circle" tabindex="0" data-bs-toggle="popover"
              data-bs-content="Ask a question about the data. The system will generate an SQL query to answer it."></i>
         </label>
-        <textarea id="prompt" name="prompt" class="form-control mb-3" rows="3">{{ prompt }}</textarea>
+        <textarea id="prompt" name="prompt" class="form-control mb-3" rows="12">{{ prompt }}</textarea>
         <input type="hidden" name="query" value="{{ query }}">
         <button type="submit" class="btn btn-primary mt-2">Submit</button>
       </form>


### PR DESCRIPTION
## Summary
- Display SQL editor, NL query form, and schema reference in a single row
- Give input forms equal column widths and matching primary submit buttons

## Testing
- `black .`
- `pytest tests/test_api.py::test_index -q` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_689390c8128c8323ba225f27fab5c433